### PR TITLE
Added onCancel listener to handle back navigation

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 KhaltiSdk_compileSdkVersion=29
 KhaltiSdk_buildToolsVersion=29.0.2
 KhaltiSdk_targetSdkVersion=29
-KhaltiSdk_latestVersion=2.00.01
+KhaltiSdk_latestVersion=2.01.00
 android.enableR8 = false

--- a/android/src/main/java/com/reactnativekhaltisdk/KhaltiSdkModule.java
+++ b/android/src/main/java/com/reactnativekhaltisdk/KhaltiSdkModule.java
@@ -18,6 +18,7 @@ import com.khalti.checkout.helper.Config;
 import com.khalti.checkout.helper.KhaltiCheckOut;
 import com.khalti.checkout.helper.PaymentPreference;
 import com.khalti.checkout.helper.OnCheckOutListener;
+import com.khalti.checkout.helper.OnCancelListener;
 
 import java.util.List;
 import java.util.Map;
@@ -73,6 +74,12 @@ public class KhaltiSdkModule extends ReactContextBaseJavaModule {
       .paymentPreferences(new ArrayList<PaymentPreference>() {{
         add(PaymentPreference.KHALTI);
       }})
+      .onCancel(new OnCancelListener() {
+        @Override
+        public void onCancel() {
+          promise.reject("PAYMENT_CANCELED", "Payment cancelled by the user");
+        }
+      })
       .additionalData(additional_data.toHashMap())
       .productUrl(product_url)
       .build();


### PR DESCRIPTION
- Rejects the promise when back button is pressed. Useful in scenarios where you are awaiting the result but the response never comes because user pressed the back button and the `await` statement is stuck forever.
- Updated Khalti android SDK version to 2.01.00